### PR TITLE
fix: preload venue show associations

### DIFF
--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -2,6 +2,16 @@
 
 # Manages Venues
 class VenuesController < BetterTogether::FriendlyResourceController
+  SHOW_PRELOADS = [
+    :map,
+    { venue_buildings: { building: %i[address space] } },
+    { venue_images: { image: { media_attachment: :blob } } },
+    { venue_offers: %i[deal_types ticket_sale_options] },
+    { stages: [{ tech_specs_attachment: :blob }, { stage_plot_attachment: :blob }, { seating_chart_attachment: :blob }] },
+    { contacts: %i[phone_numbers email_addresses addresses social_media_accounts website_links] },
+    { hosted_events: [:location, :categories, { event_hosts: :host }] }
+  ].freeze
+
   before_action if: -> { Rails.env.development? } do
     # Make sure that all BLock subclasses are loaded in dev to generate new block buttons
     BetterTogether::Content::Block.load_all_subclasses
@@ -20,5 +30,13 @@ class VenuesController < BetterTogether::FriendlyResourceController
 
   def resource_collection
     super.includes(venue_images: { image: { media_attachment: :blob } })
+  end
+
+  def set_resource_instance
+    super
+    return unless @resource&.persisted?
+
+    @resource = policy_scope(resource_class).preload(SHOW_PRELOADS).find(@resource.id)
+    instance_variable_set("@#{resource_name}", @resource)
   end
 end

--- a/spec/requests/venues_spec.rb
+++ b/spec/requests/venues_spec.rb
@@ -13,6 +13,28 @@ RSpec.describe 'Venues', type: :request do
     wizard.mark_completed
   end
 
+  def capture_select_queries
+    queries = []
+    callback = lambda do |_name, _started, _finished, _unique_id, payload|
+      sql = payload[:sql].to_s
+      next if payload[:cached]
+      next if payload[:name].in?(%w[SCHEMA TRANSACTION])
+      next unless sql.lstrip.start_with?('SELECT')
+
+      queries << sql
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { yield }
+    queries
+  end
+
+  def create_hosted_event_for(host)
+    event = create(:better_together_event, :with_simple_location)
+    create(:better_together_event_host, event:, host:)
+    event.categories << create(:event_category)
+    event
+  end
+
   describe 'URL helpers' do
     it 'generates correct venues index path' do
       expect(venues_path(locale:)).to eq("/#{locale}/venues")
@@ -43,6 +65,27 @@ RSpec.describe 'Venues', type: :request do
     it 'renders the show page' do
       get venue_path(venue, locale:)
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'keeps show-page query growth bounded when additional hosted events are rendered' do
+      create_hosted_event_for(venue)
+
+      baseline_queries = capture_select_queries do
+        get venue_path(venue, locale:)
+      end
+      expect(response).to have_http_status(:ok)
+
+      create_list(:better_together_event, 2, :with_simple_location).each do |event|
+        create(:better_together_event_host, event:, host: venue)
+        event.categories << create(:event_category)
+      end
+
+      expanded_queries = capture_select_queries do
+        get venue_path(venue, locale:)
+      end
+      expect(response).to have_http_status(:ok)
+
+      expect(expanded_queries.size - baseline_queries.size).to be <= 6
     end
   end
 end


### PR DESCRIPTION
<!-- authored-by: bts-robot -->
_💡🤖 BTS Robot 🤖💡_

## Summary
- reload venue show records through an explicit preload scope so the friendly-slug lookup path does not bypass eager loading
- preload the associations used by the venue show page, including hosted events and their hosts/categories/location
- add a request-spec regression that checks show-page query growth stays bounded as hosted events increase

## Validation
- 
- 
- 

## Notes
- Full local request-spec execution is currently blocked by pre-existing nlvenues/CE local test-environment drift (pending engine migration/setup gaps and local content-security table issues), so this PR keeps the validation focused on syntax and runtime preload loading.
